### PR TITLE
feat: Task 3 - 商品作成エンドポイントとバリデーションを実装

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,9 +1,19 @@
 from fastapi import FastAPI
 
+from api.models import ProductModel
+from api.storage import InMemoryStorage
+
 app = FastAPI(title="商品管理API")
+storage = InMemoryStorage()
 
 
 @app.get("/health", status_code=200)
 async def health_check() -> dict[str, str]:
     """ヘルスチェックエンドポイント"""
     return {"status": "ok"}
+
+
+@app.post("/items", response_model=ProductModel, status_code=201)
+async def create_item(item: ProductModel) -> ProductModel:
+    """新しい商品を登録します。"""
+    return storage.create_product(item)

--- a/api/models.py
+++ b/api/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -6,7 +7,7 @@ from pydantic import BaseModel, Field
 class ProductModel(BaseModel):
     """商品データモデル"""
 
-    id: int = Field(..., description="商品ID")
+    id: Optional[int] = Field(None, description="商品ID")
     name: str = Field(..., min_length=1, description="商品名")
     price: float = Field(..., gt=0, description="単価")
     created_at: datetime = Field(default_factory=datetime.now)

--- a/tests/api/test_items.py
+++ b/tests/api/test_items.py
@@ -1,0 +1,64 @@
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+# api.mainからappを、api.modelsからProductModelをインポートする予定
+from api.main import app
+
+# from api.models import ProductModel # Unused import - removed
+
+
+@pytest_asyncio.fixture
+async def async_client() -> AsyncClient:
+    """テスト用の非同期HTTPクライアントを提供します。"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_create_product_returns_201(async_client: AsyncClient) -> None:
+    """商品作成が成功すると201 Createdを返すことをテストします。"""
+    product_data = {"name": "Test Product", "price": 100.0}
+    response = await async_client.post("/items", json=product_data)
+    assert response.status_code == 201
+    assert "id" in response.json()
+    assert "name" in response.json()
+    assert "price" in response.json()
+    assert "created_at" in response.json()
+
+
+@pytest.mark.asyncio
+async def test_create_product_with_valid_data_returns_product(async_client: AsyncClient) -> None:
+    """有効なデータで商品を作成し、返された商品情報が正しいことをテストします。"""
+    product_data = {"name": "Another Product", "price": 250.50}
+    response = await async_client.post("/items", json=product_data)
+    response_data = response.json()
+    assert response_data["name"] == "Another Product"
+    assert response_data["price"] == 250.50
+
+
+@pytest.mark.asyncio
+async def test_create_product_with_empty_name_returns_422(async_client: AsyncClient) -> None:
+    """商品名が空の場合に422 Unprocessable Entityを返すことをテストします。"""
+    product_data = {"name": "", "price": 100.0}
+    response = await async_client.post("/items", json=product_data)
+    assert response.status_code == 422
+    assert "detail" in response.json()
+
+
+@pytest.mark.asyncio
+async def test_create_product_with_negative_price_returns_422(async_client: AsyncClient) -> None:
+    """価格が負の場合に422 Unprocessable Entityを返すことをテストします。"""
+    product_data = {"name": "Product X", "price": -10.0}
+    response = await async_client.post("/items", json=product_data)
+    assert response.status_code == 422
+    assert "detail" in response.json()
+
+
+@pytest.mark.asyncio
+async def test_create_product_with_zero_price_returns_422(async_client: AsyncClient) -> None:
+    """価格がゼロの場合に422 Unprocessable Entityを返すことをテストします。"""
+    product_data = {"name": "Product Y", "price": 0.0}
+    response = await async_client.post("/items", json=product_data)
+    assert response.status_code == 422
+    assert "detail" in response.json()


### PR DESCRIPTION
## 概要
Task #3 の実装です。商品作成エンドポイントとバリデーションを実装しました。

## 関連Issue
Fixes #3   (※Issue番号は手動で入力してください)

## 実装内容
- ✅ `tests/api/test_items.py` に `POST /items` エンドポイントの正常系・異常系テストを追加
- ✅ `api/main.py` に `POST /items` エンドポイントを実装し、Pydanticモデルによるバリデーションと `InMemoryStorage` を使った商品保存ロジックを追加
- ✅ `api/models.py` の `ProductModel` の `id` フィールドをオプションに変更し、バリデーションエラーを解消
- ✅ テストを実行し、すべてのテストがパスすることを確認
- ✅ Ruffによるコードフォーマットとリンティングの修正

## 動作確認
- `uv run --frozen pytest tests/api/test_items.py -v` でテストがパスすることを確認済みです。