### PR TITLE
feat: Task 4 - 商品取得エンドポイントとエラーハンドリングを実装

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 from api.models import ProductModel
 from api.storage import InMemoryStorage
@@ -17,3 +17,12 @@ async def health_check() -> dict[str, str]:
 async def create_item(item: ProductModel) -> ProductModel:
     """新しい商品を登録します。"""
     return storage.create_product(item)
+
+
+@app.get("/items/{item_id}", response_model=ProductModel)
+async def get_item(item_id: int) -> ProductModel:
+    """指定されたIDの商品を取得します。"""
+    product = storage.get_product_by_id(item_id)
+    if product is None:
+        raise HTTPException(status_code=404, detail="Product not found")
+    return product


### PR DESCRIPTION
## 概要
Task #4 の実装です。商品取得エンドポイントとエラーハンドリングを実装しました。

## 関連Issue
Fixes #4    (※Issue番号は手動で入力してください)

## 実装内容
- ✅ `tests/api/test_items.py` に `GET /items/{id}` エンドポイントの正常系・異常系テストを追加
- ✅ `api/main.py` に `GET /items/{id}` エンドポイントを実装し、`InMemoryStorage` を使った商品検索と404エラーハンドリングを追加
- ✅ テストを実行し、すべてのテストがパスすることを確認
- ✅ Ruffによるコードフォーマットとリンティングの修正

## 動作確認
- `uv run --frozen pytest tests/api/test_items.py -v` でテストがパスすることを確認済みです。